### PR TITLE
DevStamp v2.0: Full Soulbound NFT Implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,139 @@
 # 🧷 DevStamp
 
-An onchain protocol for minting **non-transferable "proof of contribution" stamps** (NFTs) for developers.
+An onchain protocol for minting **soulbound "proof of contribution" NFTs** for developers.
 
-## 📜 Contract Address
+## 📜 Contract Addresses
 
-[`0x49a5BD81a4AA3BbaABae0Ec846645FE8354B1e3b`](https://sepolia.basescan.org/address/0x49a5BD81a4AA3BbaABae0Ec846645FE8354B1e3b)
+### 🧪 Base Sepolia Testnet
+[`0x5a5a6f648CAA222BAB8506Eb2531138bCA1c8d7f`](https://sepolia.basescan.org/address/0x5a5a6f648CAA222BAB8506Eb2531138bCA1c8d7f)
+
+### 🌐 Base Mainnet
+[`0xea8bc2262c9813f2b1e595466475b29c72a54ba2`](https://basescan.org/address/0xea8bc2262c9813f2b1e595466475b29c72a54ba2)
 
 ## 🚀 What It Does
 
-- Mints **soulbound NFTs** as proof of contribution
-- Each developer can only mint once
-- Tokens are **non-transferable**
-- Metadata is fully onchain
+- Mints **soulbound ERC721 NFTs** as proof of developer contributions
+- Each developer can **mint exactly once** per address
+- Tokens are **permanently non-transferable** (soulbound)
+- **Fully onchain metadata** with auto-generated SVG badges
+- Self-minting system where developers create their own stamps
 
-## 🧪 Network
+## ✨ Features
 
-Deployed on **Base Sepolia Testnet**
+### 🔒 Soulbound Mechanics
+- No transfers, approvals, or sales possible
+- Permanently bound to the minting address
+- True proof of personal achievement
+
+### 🎨 Visual NFTs
+- Auto-generated SVG badges with gradient backgrounds
+- Displays contribution reason, timestamp, and token ID
+- Embedded trophy emoji and "Soulbound NFT" branding
+
+### 📊 Rich Metadata
+- Fully onchain JSON metadata
+- Structured attributes for indexing and display
+- No IPFS or external dependencies
+
+### 🔍 Query Functions
+- `getStamp(tokenId)` - Get stamp data by token ID
+- `getBuilderStamp(address)` - Get stamp data by builder address
+- `hasMinted(address)` - Check if address has already minted
+- `totalSupply()` - Total number of stamps minted
+
+## 🛠️ Usage
+
+### ⚡ Mint Your Stamp
+```solidity
+// Mint your contribution stamp (once per address)
+devStamp.stampBuilder("Built decentralized social platform");
+```
+
+### 📝 Query Stamps
+```solidity
+// Check if someone has minted
+bool minted = devStamp.hasMinted(builderAddress);
+
+// Get stamp by builder address
+Stamp memory stamp = devStamp.getBuilderStamp(builderAddress);
+
+// Get stamp by token ID
+Stamp memory stamp = devStamp.getStamp(tokenId);
+```
+
+### 📋 Stamp Data Structure
+```solidity
+struct Stamp {
+    uint256 timestamp;  // Block timestamp when minted
+    string reason;      // Contribution description
+    address builder;    // Builder's address
+}
+```
+
+## 🧪 Networks
+
+### Base Sepolia Testnet ✅
+- **Contract**: `0x5a5a6f648CAA222BAB8506Eb2531138bCA1c8d7f`
+- **Status**: Live and verified
+
+### Base Mainnet 🎉
+- **Contract**: `0xea8bc2262c9813f2b1e595466475b29c72a54ba2`
+- **Status**: Live and ready for production use!
 
 ## 🔗 Verification
 
+### Base Sepolia Testnet
 Verified on BaseScan:  
-[🔎 View on BaseScan](https://sepolia.basescan.org/address/0x49a5BD81a4AA3BbaABae0Ec846645FE8354B1e3b)
+[🔎 View on BaseScan](https://sepolia.basescan.org/address/0x5a5a6f648CAA222BAB8506Eb2531138bCA1c8d7f)
 
-## 📝 License
+### Base Mainnet
+Verified on BaseScan:  
+[🔎 View on BaseScan](https://basescan.org/address/0xea8bc2262c9813f2b1e595466475b29c72a54ba2)
+
+## 🎯 Use Cases
+
+- **📁 Portfolio Building**: Permanent onchain record of contributions
+- **⭐ Reputation Systems**: Immutable proof of developer achievements  
+- **👥 Community Recognition**: Self-sovereign achievement badges
+- **🤝 Hiring Verification**: Cryptographic proof of past work
+- **🆔 Developer Identity**: Soulbound professional credentials
+
+## 🔐 Security Features
+
+- **1️⃣ One mint per address**: Prevents spam and ensures uniqueness
+- **✅ Input validation**: Non-empty contribution reasons required
+- **🔒 Soulbound enforcement**: Multiple layers preventing transfers
+- **♾️ Immutable records**: Stamps cannot be modified after minting
+
+## 📢 Events
+
+```solidity
+event Stamped(address indexed builder, uint256 indexed tokenId, string reason);
+```
+
+## 🎨 Metadata Example
+
+```json
+{
+  "name": "DevStamp #42",
+  "description": "A soulbound proof of contribution stamp for developers",
+  "attributes": [
+    {"trait_type": "Builder", "value": "0x742d35Cc6861C4C687b78D8b5c6C2E2b2C2D2D2D"},
+    {"trait_type": "Contribution", "value": "Built awesome DeFi protocol"},
+    {"trait_type": "Timestamp", "value": 1735257600},
+    {"trait_type": "Date", "value": "Block: 1735257600"},
+    {"trait_type": "Soulbound", "value": "true"}
+  ],
+  "image": "data:image/svg+xml;base64,..."
+}
+```
+
+## 📄 License
 
 MIT
+
+---
+
+**🏗️ Build once. 🏆 Prove forever.**
+
+> 💡 **Contributing to DevStamp?** Don't forget to mint your own soulbound token (SBT) as proof of your contribution! Use `stampBuilder("Your contribution description")` to create your permanent onchain record. 🎯

--- a/contracts/DevStamp.sol
+++ b/contracts/DevStamp.sol
@@ -1,22 +1,212 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-contract DevStamp {
+import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import "@openzeppelin/contracts/utils/Strings.sol";
+import "@openzeppelin/contracts/utils/Base64.sol";
+
+contract DevStamp is ERC721 {
+    using Strings for uint256;
+    
     struct Stamp {
         uint256 timestamp;
         string reason;
+        address builder;
     }
-
-    mapping(address => Stamp[]) public builderStamps;
-
-    event Stamped(address indexed builder, string reason);
-
-    function stampBuilder(address builder, string memory reason) external {
-        builderStamps[builder].push(Stamp(block.timestamp, reason));
-        emit Stamped(builder, reason);
+    
+    // Token ID counter
+    uint256 private _tokenIdCounter;
+    
+    // Mapping from token ID to stamp data
+    mapping(uint256 => Stamp) public stamps;
+    
+    // Mapping to track if an address has already minted
+    mapping(address => bool) public hasMinted;
+    
+    // Mapping from address to their token ID
+    mapping(address => uint256) public builderToTokenId;
+    
+    event Stamped(address indexed builder, uint256 indexed tokenId, string reason);
+    
+    constructor() ERC721("DevStamp", "DEVS") {}
+    
+    /**
+     * @dev Mint a soulbound stamp NFT - can only be called once per address
+     * @param reason The contribution reason for this stamp
+     */
+    function stampBuilder(string memory reason) external {
+        require(!hasMinted[msg.sender], "DevStamp: Address has already minted");
+        require(bytes(reason).length > 0, "DevStamp: Reason cannot be empty");
+        
+        uint256 tokenId = _tokenIdCounter;
+        _tokenIdCounter++;
+        
+        // Store stamp data
+        stamps[tokenId] = Stamp({
+            timestamp: block.timestamp,
+            reason: reason,
+            builder: msg.sender
+        });
+        
+        // Mark as minted and store token ID
+        hasMinted[msg.sender] = true;
+        builderToTokenId[msg.sender] = tokenId;
+        
+        // Mint the NFT
+        _safeMint(msg.sender, tokenId);
+        
+        emit Stamped(msg.sender, tokenId, reason);
     }
-
-    function getStamps(address builder) external view returns (Stamp[] memory) {
-        return builderStamps[builder];
+    
+    /**
+     * @dev Get stamp data for a token ID
+     */
+    function getStamp(uint256 tokenId) external view returns (Stamp memory) {
+        require(_ownerOf(tokenId) != address(0), "DevStamp: Token does not exist");
+        return stamps[tokenId];
+    }
+    
+    /**
+     * @dev Get stamp data for a builder address
+     */
+    function getBuilderStamp(address builder) external view returns (Stamp memory) {
+        require(hasMinted[builder], "DevStamp: Builder has not minted");
+        uint256 tokenId = builderToTokenId[builder];
+        return stamps[tokenId];
+    }
+    
+    /**
+     * @dev Generate fully onchain metadata as base64-encoded JSON
+     */
+    function tokenURI(uint256 tokenId) public view override returns (string memory) {
+        require(_ownerOf(tokenId) != address(0), "DevStamp: URI query for nonexistent token");
+        
+        Stamp memory stamp = stamps[tokenId];
+        
+        // Format timestamp as readable date
+        string memory dateStr = _formatTimestamp(stamp.timestamp);
+        
+        // Create JSON metadata
+        string memory json = string(abi.encodePacked(
+            '{"name": "DevStamp #', tokenId.toString(),
+            '", "description": "A soulbound proof of contribution stamp for developers",',
+            '"attributes": [',
+                '{"trait_type": "Builder", "value": "', _addressToString(stamp.builder), '"},',
+                '{"trait_type": "Contribution", "value": "', stamp.reason, '"},',
+                '{"trait_type": "Timestamp", "value": ', stamp.timestamp.toString(), '},',
+                '{"trait_type": "Date", "value": "', dateStr, '"},',
+                '{"trait_type": "Soulbound", "value": "true"}',
+            '],',
+            '"image": "', _generateSVG(tokenId, stamp), '"}'
+        ));
+        
+        return string(abi.encodePacked(
+            "data:application/json;base64,",
+            Base64.encode(bytes(json))
+        ));
+    }
+    
+    /**
+     * @dev Generate an SVG image for the NFT
+     */
+    function _generateSVG(uint256 tokenId, Stamp memory stamp) internal pure returns (string memory) {
+        string memory svg = string(abi.encodePacked(
+            '<svg xmlns="http://www.w3.org/2000/svg" width="400" height="400" viewBox="0 0 400 400">',
+            '<defs><linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">',
+            '<stop offset="0%" style="stop-color:#667eea"/><stop offset="100%" style="stop-color:#764ba2"/>',
+            '</linearGradient></defs>',
+            '<rect width="400" height="400" fill="url(#bg)"/>',
+            '<circle cx="200" cy="120" r="50" fill="white" opacity="0.9"/>',
+            '<text x="200" y="130" text-anchor="middle" font-family="Arial, sans-serif" font-size="24" fill="#333">🏆</text>',
+            '<text x="200" y="200" text-anchor="middle" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white">DevStamp #', tokenId.toString(), '</text>',
+            '<text x="200" y="240" text-anchor="middle" font-family="Arial, sans-serif" font-size="14" fill="white" opacity="0.9">Soulbound NFT</text>',
+            '<text x="200" y="300" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" fill="white" opacity="0.8">Contribution:</text>',
+            '<text x="200" y="320" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="white">', 
+            _truncateString(stamp.reason, 40), '</text>',
+            '<text x="200" y="360" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="white" opacity="0.7">',
+            _formatTimestamp(stamp.timestamp), '</text>',
+            '</svg>'
+        ));
+        
+        return string(abi.encodePacked(
+            "data:image/svg+xml;base64,",
+            Base64.encode(bytes(svg))
+        ));
+    }
+    
+    /**
+     * @dev Override transfer functions to make tokens soulbound (non-transferable)
+     */
+    function _update(address to, uint256 tokenId, address auth) internal override returns (address) {
+        address from = _ownerOf(tokenId);
+        
+        // Allow minting (from == address(0)) but block all transfers
+        if (from != address(0) && to != address(0)) {
+            revert("DevStamp: Soulbound tokens cannot be transferred");
+        }
+        
+        return super._update(to, tokenId, auth);
+    }
+    
+    /**
+     * @dev Override approve to prevent approvals (since tokens can't be transferred)
+     */
+    function approve(address, uint256) public pure override {
+        revert("DevStamp: Soulbound tokens cannot be approved");
+    }
+    
+    /**
+     * @dev Override setApprovalForAll to prevent approvals
+     */
+    function setApprovalForAll(address, bool) public pure override {
+        revert("DevStamp: Soulbound tokens cannot be approved");
+    }
+    
+    /**
+     * @dev Utility function to convert address to string
+     */
+    function _addressToString(address addr) internal pure returns (string memory) {
+        bytes32 value = bytes32(uint256(uint160(addr)));
+        bytes memory alphabet = "0123456789abcdef";
+        bytes memory str = new bytes(42);
+        str[0] = '0';
+        str[1] = 'x';
+        for (uint256 i = 0; i < 20; i++) {
+            str[2+i*2] = alphabet[uint8(value[i + 12] >> 4)];
+            str[3+i*2] = alphabet[uint8(value[i + 12] & 0x0f)];
+        }
+        return string(str);
+    }
+    
+    /**
+     * @dev Format timestamp into readable date string
+     */
+    function _formatTimestamp(uint256 timestamp) internal pure returns (string memory) {
+        // Simple date formatting - you could make this more sophisticated
+        return string(abi.encodePacked("Block: ", timestamp.toString()));
+    }
+    
+    /**
+     * @dev Truncate string to specified length
+     */
+    function _truncateString(string memory str, uint256 maxLength) internal pure returns (string memory) {
+        bytes memory strBytes = bytes(str);
+        if (strBytes.length <= maxLength) {
+            return str;
+        }
+        
+        bytes memory truncated = new bytes(maxLength - 3);
+        for (uint256 i = 0; i < maxLength - 3; i++) {
+            truncated[i] = strBytes[i];
+        }
+        
+        return string(abi.encodePacked(truncated, "..."));
+    }
+    
+    /**
+     * @dev Get total number of stamps minted
+     */
+    function totalSupply() external view returns (uint256) {
+        return _tokenIdCounter;
     }
 }


### PR DESCRIPTION
What I Built
I completely rewrote the DevStamp contract from scratch to actually deliver on what the README promised. The original version was just a simple logging system that stored timestamps and reasons in a mapping - it wasn't creating any NFTs at all.
The Problem I Solved
The original contract had a major disconnect between what it claimed to do (mint soulbound NFTs) and what it actually did (just log entries). Users expected real NFTs but got basic data storage instead. Plus, there was no limit on how many "stamps" someone could create, which defeated the whole "proof of contribution" concept.
What's New
Real NFT Implementation

Built on ERC721 standard with proper token minting
Each stamp is now an actual NFT that shows up in wallets and marketplaces
Auto-generates beautiful SVG artwork for each token

True Soulbound Mechanics

Tokens literally cannot be transferred once minted
No approvals, no sales, no trading - they're permanently yours
Multiple safeguards prevent any workarounds

One Stamp Per Developer

You can only mint once per address, making each stamp unique and meaningful
Creates real scarcity and prevents spam

Fully Onchain Everything

All metadata lives on the blockchain, no IPFS dependencies
SVG images are generated and stored directly in the contract
Will work forever, even if external services go down

Live Deployments
We're now live on both networks:

Testing: Base Sepolia at 0x5a5a6f648CAA222BAB8506Eb2531138bCA1c8d7f
Production: Base Mainnet at 0xea8bc2262c9813f2b1e595466475b29c72a54ba2

